### PR TITLE
Fix reopen session flow (when called with IsRead=false)

### DIFF
--- a/Simple Facebook/src/com/sromku/simple/fb/SimpleFacebook.java
+++ b/Simple Facebook/src/com/sromku/simple/fb/SimpleFacebook.java
@@ -1629,25 +1629,27 @@ public class SimpleFacebook
 		if (request != null)
 		{
 			request.setDefaultAudience(mConfiguration.getSessionDefaultAudience());
-			request.setPermissions(mConfiguration.getReadPermissions());
 			request.setLoginBehavior(mConfiguration.getSessionLoginBehavior());
-
-			/*
-			 * In case there are also PUBLISH permissions, then we would ask for these permissions second time
-			 * (after, user accepted the read permissions)
-			 */
-			if (mConfiguration.hasPublishPermissions())
-			{
-				mSessionStatusCallback.askPublishPermissions();
-			}
 
 			if (isRead)
 			{
-				// Open session with read permissions
+                request.setPermissions(mConfiguration.getReadPermissions());
+
+                /*
+                 * In case there are also PUBLISH permissions, then we would ask for these permissions second time
+                 * (after, user accepted the read permissions)
+                 */
+                if (mConfiguration.hasPublishPermissions())
+                {
+                    mSessionStatusCallback.askPublishPermissions();
+                }
+
+                // Open session with read permissions
 				session.openForRead(request);
 			}
 			else
 			{
+                request.setPermissions(mConfiguration.getPublishPermissions());
 				session.openForPublish(request);
 			}
 		}


### PR DESCRIPTION
So I dived into the code, and encountered a problem:
In a scenario when a session exists and needs to be reopened, and the needed permissions are publish which are already authorized in the existing session the original code would do that:

```
openSession(session, false);
```

And then `openSession` will try to do that:

```
request.setPermissions(mConfiguration.getReadPermissions()); // Set only read permissions to the request
session.openForPublish(request); // Open for publish with only read permissions
```

And it will always fail with the following `FacebookException`: 

> "Cannot request publish or manage authorization with no permissions."

because `session.open` validates the permissions and sees there are no publish permissions in the request.
What I did is split the `setPermissions` parts to two scenarios: 
1. We want to open a session with a read (and optionally publish) permission
2. We want to reopen a session with a publish permission

Hope I described it properly, and of course waiting for any input / questions / corrections.
