### PR TITLE
Retrieve Permissions by value

### DIFF
--- a/Simple Facebook/src/com/sromku/simple/fb/Permissions.java
+++ b/Simple Facebook/src/com/sromku/simple/fb/Permissions.java
@@ -121,4 +121,14 @@ public enum Permissions
 	{
 		return mType;
 	}
+	
+	public static Permissions findPermission(String value)
+	{
+		for (Permissions p : Permissions.values()) {
+			if(p.getValue().equals(value)) return p;
+		}
+		return null;
+	}
 }
+
+


### PR DESCRIPTION
Added a static method to Permissions to search and retrieve a
Permissions object by its string value. This may be needed when external
clients of lib create Permissions passed as plain text.
