### PR TITLE
proguard: Avoid missing field name for gson parsing

### DIFF
--- a/simple-fb/build.gradle
+++ b/simple-fb/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion 22
         versionName project.VERSION_NAME
         versionCode Integer.parseInt(project.VERSION_CODE)
-        consumerProguardFiles 'consumer-proguard-rules.pro'
+        consumerProguardFiles 'consumer-proguard-rules.pro', 'gson.pro', 'simple-fb.pro'
     }
 
     buildTypes {

--- a/simple-fb/gson.pro
+++ b/simple-fb/gson.pro
@@ -1,0 +1,14 @@
+## GSON 2.2.4 specific rules ##
+
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+-keepattributes EnclosingMethod
+
+# Gson specific classes
+-keep class sun.misc.Unsafe { *; }
+-keep class com.google.gson.stream.** { *; }

--- a/simple-fb/simple-fb.pro
+++ b/simple-fb/simple-fb.pro
@@ -1,0 +1,1 @@
+-keep class com.sromku.simple.fb.entities.** { *; }


### PR DESCRIPTION
gson.pro is imported from https://github.com/krschultz/android-proguard-snippets/blob/master/libraries/proguard-gson.pro

Verify:

```sh
./gradle :sample:assembleRelease
cd sample/build/outputs/apk
unzip sample-release.apk
dex2jar classes.dex
unzip classes_dex2jar.jar
javap com/sromku/simple/fb/entities/* | less
```
