### PR TITLE
Updated to support fb lib version 4.6.0 and graph 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since my feeling was that the usage of Facebook SDK was too complicated for simp
 ## Latest Release
 ``` gradle
 dependencies {
-    compile 'com.sromku:simple-fb:4.0.7'
+    compile 'com.sromku:simple-fb:4.0.8'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since my feeling was that the usage of Facebook SDK was too complicated for simp
 ## Latest Release
 ``` gradle
 dependencies {
-    compile 'com.sromku:simple-fb:4.0.6'
+    compile 'com.sromku:simple-fb:4.0.7'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=4.0.6
-VERSION_CODE=406
+VERSION_NAME=4.0.7
+VERSION_CODE=407
 GROUP=com.sromku
 
 POM_DESCRIPTION=Simple Facebook SDK

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=4.0.7
-VERSION_CODE=407
+VERSION_NAME=4.0.8
+VERSION_CODE=408
 GROUP=com.sromku
 
 POM_DESCRIPTION=Simple Facebook SDK

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
   defaultConfig {
     applicationId "com.sromku.simple.fb.example"
-    minSdkVersion 14
+    minSdkVersion 15
     targetSdkVersion 22
     versionCode 1
     versionName "1.0"
@@ -21,9 +21,16 @@ android {
   }
 }
 
+allprojects {
+    repositories {
+        jcenter()
+        mavenCentral()
+    }
+}
+
 dependencies {
   compile project(':simple-fb')
   // compile project(':facebook')
   // compile 'com.sromku:simple-fb:4.0.+'
-  compile 'com.facebook.android:facebook-android-sdk:4.3.+'
+  compile 'com.facebook.android:facebook-android-sdk:4.6.+'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -23,7 +23,6 @@ android {
 
 allprojects {
     repositories {
-        jcenter()
         mavenCentral()
     }
 }

--- a/sample/src/main/java/com/sromku/simple/fb/example/SampleApplication.java
+++ b/sample/src/main/java/com/sromku/simple/fb/example/SampleApplication.java
@@ -23,7 +23,7 @@ public class SampleApplication extends Application {
 
         // initialize facebook configuration
         Permission[] permissions = new Permission[] {
-                Permission.USER_ABOUT_ME,
+                // Permission.PUBLIC_PROFILE,
                 Permission.EMAIL,
                 Permission.USER_EVENTS,
                 Permission.USER_ACTIONS_MUSIC,
@@ -39,6 +39,7 @@ public class SampleApplication extends Application {
                 .setPermissions(permissions)
                 .setDefaultAudience(DefaultAudience.FRIENDS)
                 .setAskForAllPermissionsAtOnce(false)
+                // .setGraphVersion("v2.3")
                 .build();
 
         SimpleFacebook.setConfiguration(configuration);

--- a/sample/src/main/java/com/sromku/simple/fb/example/SampleApplication.java
+++ b/sample/src/main/java/com/sromku/simple/fb/example/SampleApplication.java
@@ -23,14 +23,14 @@ public class SampleApplication extends Application {
 
         // initialize facebook configuration
         Permission[] permissions = new Permission[] {
-                Permission.PUBLIC_PROFILE,
+                Permission.USER_ABOUT_ME,
                 Permission.EMAIL,
                 Permission.USER_EVENTS,
                 Permission.USER_ACTIONS_MUSIC,
                 Permission.USER_FRIENDS,
                 Permission.USER_GAMES_ACTIVITY,
                 Permission.USER_BIRTHDAY,
-                Permission.USER_GROUPS,
+                Permission.USER_MANAGED_GROUPS,
                 Permission.PUBLISH_ACTION };
 
         SimpleFacebookConfiguration configuration = new SimpleFacebookConfiguration.Builder()

--- a/sample/src/main/java/com/sromku/simple/fb/example/fragments/GetProfileFragment.java
+++ b/sample/src/main/java/com/sromku/simple/fb/example/fragments/GetProfileFragment.java
@@ -14,6 +14,8 @@ import com.sromku.simple.fb.entities.Profile;
 import com.sromku.simple.fb.example.R;
 import com.sromku.simple.fb.example.utils.Utils;
 import com.sromku.simple.fb.listeners.OnProfileListener;
+import com.sromku.simple.fb.utils.Attributes;
+import com.sromku.simple.fb.utils.PictureAttributes;
 
 public class GetProfileFragment extends BaseFragment {
 
@@ -42,15 +44,17 @@ public class GetProfileFragment extends BaseFragment {
             @Override
             public void onClick(View v) {
 
-                // PictureAttributes pictureAttributes = Attributes.createPictureAttributes();
-                // pictureAttributes.setHeight(500);
-                // pictureAttributes.setWidth(500);
-                // pictureAttributes.setType(PictureType.SQUARE);
-                // Properties properties = new Properties.Builder()
-                //		.add(Properties.PICTURE, pictureAttributes)
-                //		.build();
+                PictureAttributes pictureAttributes = Attributes.createPictureAttributes();
+                pictureAttributes.setHeight(500);
+                pictureAttributes.setWidth(500);
+                pictureAttributes.setType(PictureAttributes.PictureType.SQUARE);
+                Profile.Properties properties = new Profile.Properties.Builder()
+                        .add(Profile.Properties.PICTURE, pictureAttributes)
+                        .add(Profile.Properties.FIRST_NAME)
+                        .add(Profile.Properties.LAST_NAME)
+                        .build();
 
-                SimpleFacebook.getInstance().getProfile(new OnProfileListener() {
+                SimpleFacebook.getInstance().getProfile(properties, new OnProfileListener() {
 
                     @Override
                     public void onThinking() {

--- a/sample/src/main/java/com/sromku/simple/fb/example/fragments/GetProfileFragment.java
+++ b/sample/src/main/java/com/sromku/simple/fb/example/fragments/GetProfileFragment.java
@@ -54,6 +54,7 @@ public class GetProfileFragment extends BaseFragment {
                         .add(Profile.Properties.LAST_NAME)
                         .build();
 
+                // SimpleFacebook.getInstance().getProfile(new OnProfileListener() {
                 SimpleFacebook.getInstance().getProfile(properties, new OnProfileListener() {
 
                     @Override

--- a/sample/src/main/java/com/sromku/simple/fb/example/fragments/SmartDeviceFragment.java
+++ b/sample/src/main/java/com/sromku/simple/fb/example/fragments/SmartDeviceFragment.java
@@ -48,7 +48,7 @@ public class SmartDeviceFragment extends BaseFragment{
             public void onClick(View v) {
 
                 Permission[] permissions = new Permission[] {
-                        Permission.PUBLIC_PROFILE,
+                        Permission.USER_ABOUT_ME,
                         Permission.EMAIL
                 };
 

--- a/simple-fb/build.gradle
+++ b/simple-fb/build.gradle
@@ -33,7 +33,7 @@ ext {
     siteUrl = 'https://github.com/sromku/android-simple-facebook'
     gitUrl = 'https://github.com/sromku/android-simple-facebook.git'
 
-    libraryVersion = '4.0.7'
+    libraryVersion = '4.0.8'
 
     developerId = 'sromku'
     developerName = 'Roman Kushnarenko'

--- a/simple-fb/build.gradle
+++ b/simple-fb/build.gradle
@@ -50,6 +50,7 @@ apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.
 allprojects {
     repositories {
         jcenter()
+        mavenCentral()
     }
 }
 
@@ -65,7 +66,7 @@ buildscript {
 }
 
 dependencies {
-    compile 'com.facebook.android:facebook-android-sdk:4.3.+'
+    compile 'com.facebook.android:facebook-android-sdk:4.6.+'
     // compile project(':facebook')
     compile 'com.google.code.gson:gson:1.7.2'
 }

--- a/simple-fb/build.gradle
+++ b/simple-fb/build.gradle
@@ -33,7 +33,7 @@ ext {
     siteUrl = 'https://github.com/sromku/android-simple-facebook'
     gitUrl = 'https://github.com/sromku/android-simple-facebook.git'
 
-    libraryVersion = '4.0.6'
+    libraryVersion = '4.0.7'
 
     developerId = 'sromku'
     developerName = 'Roman Kushnarenko'

--- a/simple-fb/build.gradle
+++ b/simple-fb/build.gradle
@@ -47,13 +47,6 @@ ext {
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
 
-allprojects {
-    repositories {
-        jcenter()
-        mavenCentral()
-    }
-}
-
 buildscript {
     repositories {
         jcenter()
@@ -62,6 +55,12 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.0.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
+    }
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
     }
 }
 

--- a/simple-fb/src/main/AndroidManifest.xml
+++ b/simple-fb/src/main/AndroidManifest.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.sromku.simple.fb">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.sromku.simple.fb"
+          xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk android:minSdkVersion="9"
+              tools:overrideLibrary="com.facebook.android"/>
 
     <application/>
 </manifest>

--- a/simple-fb/src/main/java/com/sromku/simple/fb/Permission.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/Permission.java
@@ -10,9 +10,31 @@ import java.util.List;
  * All facebook permissions.
  *
  * @author sromku
- * @version Graph API v2.3
+ * @version Graph API v2.4
  */
 public enum Permission {
+
+    /**
+     * This permission not longer in use in latest graph versions.
+     * Please us Permission#USER_ABOUT_ME instead.
+     *
+     * Provides access to a subset of items that are part of a person's public
+     * profile. These {@link Profile} fields can be retrieved by using this
+     * permission:<br>
+     * <ul>
+     * <li>{@link Profile.Properties#ID ID}</li>
+     * <li>{@link Profile.Properties#NAME NAME}</li>
+     * <li>{@link Profile.Properties#FIRST_NAME FIRST_NAME}</li>
+     * <li>{@link Profile.Properties#LAST_NAME LAST_NAME}</li>
+     * <li>{@link Profile.Properties#LINK LINK}</li>
+     * <li>{@link Profile.Properties#GENDER GENDER}</li>
+     * <li>{@link Profile.Properties#LOCALE LOCALE}</li>
+     * <li>{@link Profile.Properties#AGE_RANGE AGE_RANGE}</li>
+     * </ul>
+     *
+     */
+    @Deprecated
+    PUBLIC_PROFILE("public_profile", Type.READ),
 
     /**
      * Provides access to {@link Profile.Properties#BIO BIO} property of the
@@ -56,6 +78,17 @@ public enum Permission {
     USER_ACTIONS_VIDEO("user_actions.video", Type.READ),
 
     /**
+     * This permission not longer in use in latest graph versions.
+     *
+     * Provides access to a person's list of activities as listed on their
+     * Profile. This is a subset of the pages they have liked, where those pages
+     * represent particular interests. This information is accessed through the
+     * activities connection on the user node.
+     */
+    @Deprecated
+    USER_ACTIVITIES("user_activities", Type.READ),
+
+    /**
      * Access the date and month of a person's birthday. This may or may not
      * include the person's year of birth, dependent upon their privacy settings
      * and the access token being used to query this field.
@@ -89,6 +122,18 @@ public enum Permission {
     USER_GAMES_ACTIVITY("user_games_activity", Type.READ),
 
     /**
+     * This permission not longer in use in latest graph versions.
+     * Please us Permission#USER_MANAGED_GROUPS instead.
+     *
+     * Enables your app to read the Groups a person is a member of through the
+     * groups edge on the User object. This permission does not allow you to
+     * create groups on behalf of a person. It is not possible to create groups
+     * via the Graph API
+     */
+    @Deprecated
+    USER_GROUPS("user_groups", Type.READ),
+
+    /**
      * Enables your app to read the Groups a person is a member of through the
      * groups edge on the User object. This permission does not allow you to
      * create groups on behalf of a person. It is not possible to create groups
@@ -101,6 +146,15 @@ public enum Permission {
      * field on the User object. This is set by the user on the Profile.
      */
     USER_HOMETOWN("user_hometown", Type.READ),
+
+    /**
+     * This permission not longer in use in latest graph versions.
+     *
+     * Provides access to the list of interests in a person's Profile. This is a
+     * subset of the pages they have liked which represent particular interests.
+     */
+    @Deprecated
+    USER_INTERESTS("user_interests", Type.READ),
 
     /**
      * Provides access to the list of all Facebook Pages and Open Graph objects
@@ -168,6 +222,20 @@ public enum Permission {
     USER_WORK_HISTORY("user_work_history", Type.READ),
 
     /**
+     * This permission not longer in use in latest graph versions.
+     * Please us Permission#READ_CUSTOM_FRIENDLISTS instead.
+     *
+     * Provides access to the names of custom lists a person has created to organize their friends.
+     * This is useful for rendering an audience selector when someone is publishing stories
+     * to Facebook from your app.
+     *
+     * This permission does not give access to a list of person's friends. If you want to access
+     * a person's friends who also use your app, you should use the user_friends permission.
+     */
+    @Deprecated
+    READ_FRIENDLISTS("read_friendlists", Type.READ),
+
+    /**
      * Provides access to the names of custom lists a person has created to organize their friends.
      * This is useful for rendering an audience selector when someone is publishing stories
      * to Facebook from your app.
@@ -182,6 +250,25 @@ public enum Permission {
      * domains the person owns.
      */
     READ_INSIGHTS("read_insights", Type.READ),
+
+    /**
+     * This permission not longer in use in latest graph versions.
+     *
+     * Provides the ability to read the messages in a person's Facebook Inbox
+     * through the inbox edge and the thread node
+     */
+    @Deprecated
+    READ_MAILBOX("read_mailbox", Type.READ),
+
+    /**
+     * This permission not longer in use in latest graph versions.
+     * Please us Permission#USER_POSTS instead.
+     *
+     * Provides access to read the posts in a person's News Feed, or the posts
+     * on their Profile.
+     */
+    @Deprecated
+    READ_STREAM("read_stream", Type.READ),
 
     /**
      * Provides the ability to read from the Page Inboxes of the Pages managed
@@ -235,6 +322,15 @@ public enum Permission {
      * is no way to create an event via the API as of Graph API v2.0.
      */
     RSVP_EVENT("rsvp_event", Type.PUBLISH),
+
+    /**
+     * This permission not longer in use in latest graph versions.
+     *
+     * Enables your app to read a person's notifications and mark them as read.
+     * This permission does not let you send notifications to a person.
+     */
+    @Deprecated
+    MANAGE_NOTIFICATIONS("manage_notifications", Type.PUBLISH),
 
     /**
      * Enables your app to retrieve Page Access Tokens for the Pages and Apps

--- a/simple-fb/src/main/java/com/sromku/simple/fb/Permission.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/Permission.java
@@ -15,24 +15,6 @@ import java.util.List;
 public enum Permission {
 
     /**
-     * Provides access to a subset of items that are part of a person's public
-     * profile. These {@link Profile} fields can be retrieved by using this
-     * permission:<br>
-     * <ul>
-     * <li>{@link Profile.Properties#ID ID}</li>
-     * <li>{@link Profile.Properties#NAME NAME}</li>
-     * <li>{@link Profile.Properties#FIRST_NAME FIRST_NAME}</li>
-     * <li>{@link Profile.Properties#LAST_NAME LAST_NAME}</li>
-     * <li>{@link Profile.Properties#LINK LINK}</li>
-     * <li>{@link Profile.Properties#GENDER GENDER}</li>
-     * <li>{@link Profile.Properties#LOCALE LOCALE}</li>
-     * <li>{@link Profile.Properties#AGE_RANGE AGE_RANGE}</li>
-     * </ul>
-     *
-     */
-    PUBLIC_PROFILE("public_profile", Type.READ),
-
-    /**
      * Provides access to {@link Profile.Properties#BIO BIO} property of the
      * {@link Profile}
      */
@@ -74,14 +56,6 @@ public enum Permission {
     USER_ACTIONS_VIDEO("user_actions.video", Type.READ),
 
     /**
-     * Provides access to a person's list of activities as listed on their
-     * Profile. This is a subset of the pages they have liked, where those pages
-     * represent particular interests. This information is accessed through the
-     * activities connection on the user node.
-     */
-    USER_ACTIVITIES("user_activities", Type.READ),
-
-    /**
      * Access the date and month of a person's birthday. This may or may not
      * include the person's year of birth, dependent upon their privacy settings
      * and the access token being used to query this field.
@@ -120,19 +94,13 @@ public enum Permission {
      * create groups on behalf of a person. It is not possible to create groups
      * via the Graph API
      */
-    USER_GROUPS("user_groups", Type.READ),
+    USER_MANAGED_GROUPS("user_managed_groups", Type.READ),
 
     /**
      * Provides access to a person's hometown location through the hometown
      * field on the User object. This is set by the user on the Profile.
      */
     USER_HOMETOWN("user_hometown", Type.READ),
-
-    /**
-     * Provides access to the list of interests in a person's Profile. This is a
-     * subset of the pages they have liked which represent particular interests.
-     */
-    USER_INTERESTS("user_interests", Type.READ),
 
     /**
      * Provides access to the list of all Facebook Pages and Open Graph objects
@@ -200,35 +168,20 @@ public enum Permission {
     USER_WORK_HISTORY("user_work_history", Type.READ),
 
     /**
-     * Provides access to the names of custom lists a person has created to
-     * organize their friends. This is useful for rendering an audience selector
-     * when someone is publishing stories to Facebook from your app. This
-     * permission does not give access to a list of person's friends. If you
-     * want to access a person's friends who also use your app, you should use
-     * the user_friends permission. This permission also does not give the list
-     * of friends who are part of a friendlist. It only gives access to the
-     * names of the lists.<br>
-     * <br>
+     * Provides access to the names of custom lists a person has created to organize their friends.
+     * This is useful for rendering an audience selector when someone is publishing stories
+     * to Facebook from your app.
      *
-     * <b>Note:</b><br>
-     * Extended Permissions give access to more sensitive information and give
-     * your app the ability to publish and delete data. All extended permissions
-     * appear on a separate screen during the login flow so a person can decide
-     * if they want to grant them.
+     * This permission does not give access to a list of person's friends. If you want to access
+     * a person's friends who also use your app, you should use the user_friends permission.
      */
-    READ_FRIENDLISTS("read_friendlists", Type.READ),
+    READ_CUSTOM_FRIENDLISTS("read_custom_friendlists", Type.READ),
 
     /**
      * Provides read-only access to the Insights data for Pages, Apps and web
      * domains the person owns.
      */
     READ_INSIGHTS("read_insights", Type.READ),
-
-    /**
-     * Provides the ability to read the messages in a person's Facebook Inbox
-     * through the inbox edge and the thread node
-     */
-    READ_MAILBOX("read_mailbox", Type.READ),
 
     /**
      * Provides the ability to read from the Page Inboxes of the Pages managed
@@ -241,12 +194,6 @@ public enum Permission {
     READ_PAGE_MAILBOX("read_page_mailboxes", Type.READ),
 
     /**
-     * Provides access to read the posts in a person's News Feed, or the posts
-     * on their Profile.
-     */
-    READ_STREAM("read_stream", Type.READ),
-
-    /**
      * Provides access to the person's primary email address via the
      * {@link Profile.Properties#EMAIL} property on the {@link Profile} object.<br>
      * <br>
@@ -256,6 +203,23 @@ public enum Permission {
      * a phone number instead of an email address, the email field may be empty.
      */
     EMAIL("email", Type.READ),
+
+    /**
+     * Provides access to the posts on a person's Timeline. Includes their own posts,
+     * posts they are tagged in, and posts other people make on their Timeline.
+     */
+    USER_POSTS("user_posts", Type.READ),
+
+    /**
+     * Provides the access to Ads Insights API to pull ads report information for ad
+     * accounts you have access to.
+     */
+    ADS_READ("ads_read", Type.READ),
+
+    /**
+     * Provides read-only access to the Audience Network Insights data for Apps the person owns.
+     */
+    READ_AUDIENCE_NETWORK_INSIGHTS("read_audience_network_insights", Type.READ),
 
     /**
      * Provides access to publish Posts, Open Graph actions, achievements,
@@ -273,18 +237,10 @@ public enum Permission {
     RSVP_EVENT("rsvp_event", Type.PUBLISH),
 
     /**
-     * Enables your app to read a person's notifications and mark them as read.
-     * This permission does not let you send notifications to a person.
-     */
-    MANAGE_NOTIFICATIONS("manage_notifications", Type.PUBLISH),
-
-    /**
      * Enables your app to retrieve Page Access Tokens for the Pages and Apps
      * that the person administrates.
      */
     MANAGE_PAGES("manage_pages", Type.PUBLISH);
-
-    // TODO - add support for new permission: 'user_actions:{app_namespace}'
 
     /**
      * Permission type enum: <li>READ</li> <li>PUBLISH</li><br>

--- a/simple-fb/src/main/java/com/sromku/simple/fb/SimpleFacebookConfiguration.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/SimpleFacebookConfiguration.java
@@ -1,5 +1,6 @@
 package com.sromku.simple.fb;
 
+import com.facebook.internal.ServerProtocol;
 import com.facebook.login.DefaultAudience;
 import com.facebook.login.LoginBehavior;
 
@@ -18,6 +19,7 @@ public class SimpleFacebookConfiguration {
     boolean mAllAtOnce = false;
     private boolean mUseAppsecretProof = false;
     private String mAppSecret = null;
+    private String mGraphVersion = null;
 
     private SimpleFacebookConfiguration(Builder builder) {
         this.mAppId = builder.mAppId;
@@ -29,6 +31,7 @@ public class SimpleFacebookConfiguration {
         this.mAllAtOnce = builder.mAllAtOnce;
         this.mUseAppsecretProof = builder.mUseAppsecretProof;
         this.mAppSecret = builder.mAppSecret;
+        this.mGraphVersion = builder.mGraphVersion;
 
         if (this.mPublishPermissions.size() > 0) {
             this.mHasPublishPermissions = true;
@@ -37,8 +40,6 @@ public class SimpleFacebookConfiguration {
 
     /**
      * Get facebook application id
-     *
-     * @return
      */
     public String getAppId() {
         return mAppId;
@@ -46,8 +47,6 @@ public class SimpleFacebookConfiguration {
 
     /**
      * Get application namespace
-     *
-     * @return
      */
     public String getNamespace() {
         return mNamespace;
@@ -55,8 +54,6 @@ public class SimpleFacebookConfiguration {
 
     /**
      * Get read permissions
-     *
-     * @return
      */
     public List<String> getReadPermissions() {
         return mReadPermissions;
@@ -64,17 +61,20 @@ public class SimpleFacebookConfiguration {
 
     /**
      * Get publish permissions
-     *
-     * @return
      */
     public List<String> getPublishPermissions() {
         return mPublishPermissions;
     }
 
     /**
+     * Get graph version
+     */
+    public String getGraphVersion() {
+        return mGraphVersion;
+    }
+
+    /**
      * Return <code>True</code> if 'PUBLISH' permissions are defined
-     *
-     * @return
      */
     boolean hasPublishPermissions() {
         return mHasPublishPermissions;
@@ -163,6 +163,7 @@ public class SimpleFacebookConfiguration {
         private boolean mAllAtOnce = false;
         private boolean mUseAppsecretProof = false;
         private String mAppSecret = null;
+        private String mGraphVersion = ServerProtocol.getAPIVersion();
 
         public Builder() {
         }
@@ -273,6 +274,15 @@ public class SimpleFacebookConfiguration {
          */
         public Builder setAppSecret(String appSecret) {
             mAppSecret = appSecret;
+            return this;
+        }
+
+        /**
+         * Set graph version if you want to use older versions.
+         * The format should be v{X.X} for example: v2.3, v2.4
+         */
+        public Builder setGraphVersion(String graphVersion) {
+            mGraphVersion = graphVersion;
             return this;
         }
 

--- a/simple-fb/src/main/java/com/sromku/simple/fb/SimpleFacebookConfiguration.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/SimpleFacebookConfiguration.java
@@ -159,7 +159,7 @@ public class SimpleFacebookConfiguration {
         private List<String> mReadPermissions = new ArrayList<String>();
         private List<String> mPublishPermissions = new ArrayList<String>();
         private DefaultAudience mDefaultAudience = DefaultAudience.FRIENDS;
-        private LoginBehavior mLoginBehavior = LoginBehavior.SSO_WITH_FALLBACK;
+        private LoginBehavior mLoginBehavior = LoginBehavior.NATIVE_WITH_FALLBACK;
         private boolean mAllAtOnce = false;
         private boolean mUseAppsecretProof = false;
         private String mAppSecret = null;

--- a/simple-fb/src/main/java/com/sromku/simple/fb/actions/GetAction.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/actions/GetAction.java
@@ -82,6 +82,7 @@ public class GetAction<T> extends AbstractAction {
             AccessToken accessToken = sessionManager.getAccessToken();
             Bundle bundle = updateAppSecretProof(getBundle());
             GraphRequest request = new GraphRequest(accessToken, getGraphPath(), bundle, HttpMethod.GET);
+            request.setVersion(configuration.getGraphVersion());
             runRequest(request);
         } else {
             String reason = Errors.getError(ErrorMsg.LOGIN);

--- a/simple-fb/src/main/java/com/sromku/simple/fb/actions/PublishAction.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/actions/PublishAction.java
@@ -142,6 +142,7 @@ public class PublishAction extends AbstractAction {
                 }
             }
         });
+        request.setVersion(configuration.getGraphVersion());
         GraphRequestAsyncTask task = new GraphRequestAsyncTask(request);
         task.execute();
     }

--- a/simple-fb/src/main/java/com/sromku/simple/fb/entities/Profile.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/entities/Profile.java
@@ -115,7 +115,7 @@ public class Profile extends User {
      * Returns the ID of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the ID of the user
      */
@@ -127,7 +127,7 @@ public class Profile extends User {
      * Returns the name of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the name of the user
      */
@@ -139,7 +139,7 @@ public class Profile extends User {
      * Returns the first name of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the first name of the user
      */
@@ -151,7 +151,7 @@ public class Profile extends User {
      * Returns the middle name of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the middle name of the user
      */
@@ -163,7 +163,7 @@ public class Profile extends User {
      * Returns the last name of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the last name of the user
      */
@@ -175,7 +175,7 @@ public class Profile extends User {
      * Returns the gender of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the gender of the user
      */
@@ -187,7 +187,7 @@ public class Profile extends User {
      * Return the ISO language code and ISO country code of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the ISO language code and ISO country code of the user
      */
@@ -211,7 +211,7 @@ public class Profile extends User {
      * Returns the Facebook URL of the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the Facebook URL of the user
      */
@@ -223,7 +223,7 @@ public class Profile extends User {
      * The user's age range. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the user's age range
      */
@@ -235,7 +235,7 @@ public class Profile extends User {
      * An anonymous, but unique identifier for the user. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return the an anonymous, but unique identifier for the user
      */
@@ -248,7 +248,7 @@ public class Profile extends User {
      * the app access token that is used to make the request. <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return <code>True</code> if installed, otherwise <code>False</code>
      */
@@ -260,7 +260,7 @@ public class Profile extends User {
      * Return the timezone of the user.<br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * <br>
      * <br>
@@ -280,7 +280,7 @@ public class Profile extends User {
      * value.<br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * <br>
      * <br>
@@ -295,7 +295,7 @@ public class Profile extends User {
      * The user's account verification status.<br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * <br>
      * <br>
@@ -340,7 +340,7 @@ public class Profile extends User {
      * {@link com.sromku.simple.fb.entities.Photo#getSource()} <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return The user's cover photo
      */
@@ -352,7 +352,7 @@ public class Profile extends User {
      * The user's currency settings <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return The user's currency settings
      */
@@ -448,7 +448,7 @@ public class Profile extends User {
      * The user's profile pic <br>
      * <br>
      * <b> Permissions:</b><br>
-     * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+     * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
      *
      * @return The user's profile pic
      */
@@ -543,7 +543,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String ID = "id";
@@ -554,7 +554,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String NAME = "name";
@@ -565,7 +565,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String FIRST_NAME = "first_name";
@@ -576,7 +576,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String MIDDLE_NAME = "middle_name";
@@ -587,7 +587,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String LAST_NAME = "last_name";
@@ -598,7 +598,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String GENDER = "gender";
@@ -609,7 +609,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String LOCALE = "locale";
@@ -631,7 +631,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String LINK = "link";
@@ -642,7 +642,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String AGE_RANGE = "age_range";
@@ -653,7 +653,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String THIRD_PARTY_ID = "third_party_id";
@@ -665,7 +665,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String INSTALLED = "installed";
@@ -676,7 +676,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String TIMEZONE = "timezone";
@@ -690,7 +690,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String UPDATED_TIME = "updated_time";
@@ -701,7 +701,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String VERIFIED = "verified";
@@ -734,7 +734,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String COVER = "cover";
@@ -745,7 +745,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String CURRENCY = "currency";
@@ -756,7 +756,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String DEVICES = "devices";
@@ -837,7 +837,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String PAYMENT_PRICEPOINTS = "payment_pricepoints";
@@ -849,7 +849,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String PAYMENT_MOBILE_PRICEPOINTS = "payment_mobile_pricepoints";
@@ -882,7 +882,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String PICTURE = "picture";
@@ -928,7 +928,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String SECURITY_SETTINGS = "security_settings";
@@ -951,7 +951,7 @@ public class Profile extends User {
          * <br>
          *
          * <b>Permissions:</b><br>
-         * {@link com.sromku.simple.fb.Permission#PUBLIC_PROFILE}
+         * {@link com.sromku.simple.fb.Permission#USER_ABOUT_ME}
          *
          */
         public static final String VIDEO_UPLOAD_LIMITS = "video_upload_limits";


### PR DESCRIPTION
Changes:

1. Updated permissions: 
 - Deprecated: `PUBLIC_PROFILE`
 - Deprecated: `USER_ACTIVITIES`
 - Deprecated: `USER_INTERESTS`
 - Deprecated: `READ_MAILBOX`
 - Deprecated: `READ_STREAM` 
 - Deprecated: `MANAGE_NOTIFICATIONS`
 - Added: `USER_MANAGED_GROUPS` (previously it was: `USER_GROUPS`)
 - Added: `READ_CUSTOM_FRIENDLISTS` (previously it was: `READ_FRIENDLISTS`)
 - Added: `USER_POSTS`
 - Added: `ADS_READ`
 - Added: `READ_AUDIENCE_NETWORK_INSIGHTS`

2. FB updated min SDK to be 15. Here, we added override to this version to be 9 as always

3. Updated docs and samples

4. New configuration option to set older graph api version

``` java
SimpleFacebookConfiguration configuration = new SimpleFacebookConfiguration.Builder()
    ...
    .setGraphVersion("v2.3")
    .build();
```