### PR TITLE
Update Profile to use IdName for hometown and location fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Everything is explained in [**wiki**](https://github.com/sromku/android-simple-f
 - [bperin](https://github.com/bperin)
 - [Norbert Schuler](https://github.com/norbertschuler)
 - [Chang Yu-heng](https://github.com/changyuheng)
+- [Samed Ozdemir](https://github.com/xsorifc28)
+- [Filipe de Lima Brito](https://github.com/filipedelimabrito)
 
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-android--simple--facebook-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/949)
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -23,7 +23,7 @@ android {
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }
 
@@ -31,5 +31,5 @@ dependencies {
   compile project(':simple-fb')
   // compile project(':facebook')
   // compile 'com.sromku:simple-fb:4.0.+'
-  compile 'com.facebook.android:facebook-android-sdk:4.6.+'
+  // compile 'com.facebook.android:facebook-android-sdk:4.6.+'
 }

--- a/simple-fb/build.gradle
+++ b/simple-fb/build.gradle
@@ -65,7 +65,7 @@ allprojects {
 }
 
 dependencies {
-    compile 'com.facebook.android:facebook-android-sdk:4.6.+'
+    compile 'com.facebook.android:facebook-android-sdk:4.7.+'
     // compile project(':facebook')
     compile 'com.google.code.gson:gson:1.7.2'
 }

--- a/simple-fb/src/main/java/com/sromku/simple/fb/entities/Hometown.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/entities/Hometown.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 /**
  * Created by sromku on 7/3/15.
  */
+@Deprecated
 public class Hometown extends IdName {
 
     @Override

--- a/simple-fb/src/main/java/com/sromku/simple/fb/entities/Location.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/entities/Location.java
@@ -2,7 +2,7 @@ package com.sromku.simple.fb.entities;
 
 import com.google.gson.annotations.SerializedName;
 
-public class Location extends IdName {
+public class Location {
 
     private static final String STREET = "street";
     private static final String CITY = "city";

--- a/simple-fb/src/main/java/com/sromku/simple/fb/entities/Location.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/entities/Location.java
@@ -25,7 +25,7 @@ public class Location {
     private String mCountry;
 
     @SerializedName(ZIP)
-    private Integer mZip;
+    private String mZip;
 
     @SerializedName(LATITUDE)
     private Double mLatitude;
@@ -49,7 +49,7 @@ public class Location {
         return mCountry;
     }
 
-    public Integer getZip() {
+    public String getZip() {
         return mZip;
     }
 

--- a/simple-fb/src/main/java/com/sromku/simple/fb/entities/Location.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/entities/Location.java
@@ -2,7 +2,7 @@ package com.sromku.simple.fb.entities;
 
 import com.google.gson.annotations.SerializedName;
 
-public class Location {
+public class Location extends IdName {
 
     private static final String STREET = "street";
     private static final String CITY = "city";

--- a/simple-fb/src/main/java/com/sromku/simple/fb/entities/Profile.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/entities/Profile.java
@@ -79,16 +79,16 @@ public class Profile extends User {
     private String mEmail;
 
     @SerializedName(Properties.HOMETOWN)
-    private Hometown mHometown;
+    private IdName mHometown;
 
     @SerializedName(Properties.LOCATION)
-    private Location mLocation;
+    private IdName mCurrentLocation;
 
     @SerializedName(Properties.POLITICAL)
     private String mPolitical;
 
     @SerializedName(Properties.FAVORITE_ATHLETES)
-    private List<String> mFavoriteAthletess;
+    private List<String> mFavoriteAthletes;
 
     @SerializedName(Properties.FAVORITE_TEAMS)
     private List<String> mFavoriteTeams;
@@ -390,22 +390,22 @@ public class Profile extends User {
      * <b> Permissions:</b><br>
      * {@link com.sromku.simple.fb.Permission#USER_HOMETOWN}<br>
      *
-     * @return The user's hometown
+     * @return The page id and name of the Place set as user's hometown
      */
-    public Hometown getHometown() {
+    public IdName getHometown() {
         return mHometown;
     }
 
     /**
-     * Returns the current city of the user. <br>
+     * The user's currently "living" location <br>
      * <br>
      * <b> Permissions:</b><br>
      * {@link com.sromku.simple.fb.Permission#USER_LOCATION}<br>
      *
-     * @return the current city of the user
+     * @return The page id and name of the Place set as user's current location
      */
-    public Location getLocation() {
-        return mLocation;
+    public IdName getLocation() {
+        return mCurrentLocation;
     }
 
     /**
@@ -429,7 +429,7 @@ public class Profile extends User {
      * @return The user's favorite athletes
      */
     public List<String> getFavoriteAthletes() {
-        return mFavoriteAthletess;
+        return mFavoriteAthletes;
     }
 
     /**

--- a/simple-fb/src/main/java/com/sromku/simple/fb/entities/Profile.java
+++ b/simple-fb/src/main/java/com/sromku/simple/fb/entities/Profile.java
@@ -377,7 +377,7 @@ public class Profile extends User {
      * <br>
      * <b> Permissions:</b> <br>
      * {@link com.sromku.simple.fb.Permission#EMAIL}
-     *
+     * To get the details about the place, use GetPage with this id.
      * @return the email of the user
      */
     public String getEmail() {
@@ -389,7 +389,8 @@ public class Profile extends User {
      * <br>
      * <b> Permissions:</b><br>
      * {@link com.sromku.simple.fb.Permission#USER_HOMETOWN}<br>
-     *
+     * <br>
+     * To get the details about the place, use GetPage with this id.
      * @return The page id and name of the Place set as user's hometown
      */
     public IdName getHometown() {


### PR DESCRIPTION
Since the Graph API only returns Id and name for a users current location and hometown, I think it makes sense to use just the IdName object. 

This also solves the issue of "Location" being misleading (Since it extended IdName & had physical location info).

Hometown is also not used anymore, and probably not required.

To get more info about a user's hometown or location, you must use `GetPage` with `getProfile().getHometown().getId()` or `getProfile().getLocation().getId()`.